### PR TITLE
Fix: Refine backoff retry logic for policy batch operations.

### DIFF
--- a/alicloud/resource_ram_policy.go
+++ b/alicloud/resource_ram_policy.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"slices"
 	"strings"
 	"time"
 
@@ -554,7 +553,7 @@ func (r *ramPolicyResource) createPolicy(ctx context.Context, plan *ramPolicyRes
 	// These policies will be attached directly to the user since splitting the
 	// policy "statement" will be hitting the limitation of "maximum number of
 	// attached policies" easily.
-	combinedPoliciesDetail = slices.Concat(combinedPoliciesDetail, excludedPolicies)
+	combinedPoliciesDetail = append(combinedPoliciesDetail, excludedPolicies...)
 	return combinedPoliciesDetail, attachedPoliciesDetail, nil
 }
 

--- a/alicloud/resource_ram_policy.go
+++ b/alicloud/resource_ram_policy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -435,10 +436,9 @@ func (r *ramPolicyResource) ImportState(ctx context.Context, req resource.Import
 	var username string
 
 	var err error
-	getPolicy := func() error {
-		runtime := &util.RuntimeOptions{}
-
-		for _, policyName := range policyNames {
+	for _, policyName := range policyNames {
+		getPolicy := func() error {
+			runtime := &util.RuntimeOptions{}
 			policyName = strings.ReplaceAll(policyName, " ", "")
 
 			// Retrieves the policy document for the policy
@@ -446,7 +446,6 @@ func (r *ramPolicyResource) ImportState(ctx context.Context, req resource.Import
 				PolicyName: tea.String(policyName),
 				PolicyType: tea.String("Custom"),
 			}
-
 			getPolicyResponse, err = r.client.GetPolicyWithOptions(getPolicyRequest, runtime)
 			if err != nil {
 				handleAPIError(err)
@@ -457,7 +456,6 @@ func (r *ramPolicyResource) ImportState(ctx context.Context, req resource.Import
 				PolicyName: tea.String(policyName),
 				PolicyType: tea.String("Custom"),
 			}
-
 			getPolicyEntities, err := r.client.ListEntitiesForPolicyWithOptions(listEntitiesForPolicy, runtime)
 			if err != nil {
 				handleAPIError(err)
@@ -470,21 +468,18 @@ func (r *ramPolicyResource) ImportState(ctx context.Context, req resource.Import
 				}
 				policyDetailsState = append(policyDetailsState, &policyDetail)
 			}
-
 			if getPolicyEntities.Body.Users != nil {
 				for _, user := range getPolicyEntities.Body.Users.User {
 					username = *user.UserName
 				}
 			}
+			return nil
 		}
-		return nil
-	}
-
-	reconnectBackoff := backoff.NewExponentialBackOff()
-	reconnectBackoff.MaxElapsedTime = 30 * time.Second
-	err = backoff.Retry(getPolicy, reconnectBackoff)
-	if err != nil {
-		return
+		reconnectBackoff := backoff.NewExponentialBackOff()
+		reconnectBackoff.MaxElapsedTime = 30 * time.Second
+		if err = backoff.Retry(getPolicy, reconnectBackoff); err != nil {
+			return
+		}
 	}
 
 	var policyList []policyDetail
@@ -529,12 +524,11 @@ func (r *ramPolicyResource) createPolicy(ctx context.Context, plan *ramPolicyRes
 		return nil, nil, errList
 	}
 
-	createPolicy := func() error {
-		runtime := &util.RuntimeOptions{}
+	for i, policy := range combinedPolicyDocuments {
+		policyName := fmt.Sprintf("%s-%d", plan.UserName.ValueString(), i+1)
 
-		for i, policy := range combinedPolicyDocuments {
-			policyName := fmt.Sprintf("%s-%d", plan.UserName.ValueString(), i+1)
-
+		createPolicy := func() error {
+			runtime := &util.RuntimeOptions{}
 			createPolicyRequest := &alicloudRamClient.CreatePolicyRequest{
 				PolicyName:     tea.String(policyName),
 				PolicyDocument: tea.String(policy),
@@ -543,33 +537,24 @@ func (r *ramPolicyResource) createPolicy(ctx context.Context, plan *ramPolicyRes
 			if _, err := r.client.CreatePolicyWithOptions(createPolicyRequest, runtime); err != nil {
 				return handleAPIError(err)
 			}
+			return nil
 		}
-
-		return nil
-	}
-
-	reconnectBackoff := backoff.NewExponentialBackOff()
-	reconnectBackoff.MaxElapsedTime = 30 * time.Second
-	err := backoff.Retry(createPolicy, reconnectBackoff)
-
-	if err != nil {
-		return nil, nil, []error{err}
-	}
-
-	for i, policies := range combinedPolicyDocuments {
-		policyName := fmt.Sprintf("%s-%d", plan.UserName.ValueString(), i+1)
+		reconnectBackoff := backoff.NewExponentialBackOff()
+		reconnectBackoff.MaxElapsedTime = 30 * time.Second
+		if err := backoff.Retry(createPolicy, reconnectBackoff); err != nil {
+			return nil, nil, []error{err}
+		}
 
 		combinedPoliciesDetail = append(combinedPoliciesDetail, &policyDetail{
 			PolicyName:     types.StringValue(policyName),
-			PolicyDocument: types.StringValue(policies),
+			PolicyDocument: types.StringValue(policy),
 		})
 	}
 
 	// These policies will be attached directly to the user since splitting the
 	// policy "statement" will be hitting the limitation of "maximum number of
 	// attached policies" easily.
-	combinedPoliciesDetail = append(combinedPoliciesDetail, excludedPolicies...)
-
+	combinedPoliciesDetail = slices.Concat(combinedPoliciesDetail, excludedPolicies)
 	return combinedPoliciesDetail, attachedPoliciesDetail, nil
 }
 
@@ -818,20 +803,17 @@ func (r *ramPolicyResource) checkPoliciesDrift(newState, oriState *ramPolicyReso
 // Parameters:
 //   - state: The recorded state configurations.
 func (r *ramPolicyResource) removePolicy(state *ramPolicyResourceModel) diag.Diagnostics {
-	removePolicy := func() error {
-		for _, combinedPolicy := range state.CombinedPolicesDetail {
+	for _, combinedPolicy := range state.CombinedPolicesDetail {
+		removePolicy := func() error {
 			runtime := &util.RuntimeOptions{}
-
 			detachPolicyFromUserRequest := &alicloudRamClient.DetachPolicyFromUserRequest{
 				PolicyType: tea.String("Custom"),
 				PolicyName: tea.String(combinedPolicy.PolicyName.ValueString()),
 				UserName:   tea.String(state.UserName.ValueString()),
 			}
-
 			deletePolicyRequest := &alicloudRamClient.DeletePolicyRequest{
 				PolicyName: tea.String(combinedPolicy.PolicyName.ValueString()),
 			}
-
 			if _, err := r.client.DetachPolicyFromUserWithOptions(detachPolicyFromUserRequest, runtime); err != nil {
 				// Ignore error where the policy is not attached
 				// to the user as it is intented to detach the
@@ -840,7 +822,6 @@ func (r *ramPolicyResource) removePolicy(state *ramPolicyResourceModel) diag.Dia
 					return handleAPIError(err)
 				}
 			}
-
 			if _, err := r.client.DeletePolicyWithOptions(deletePolicyRequest, runtime); err != nil {
 				// Ignore error where the policy had been deleted
 				// as it is intended to delete the RAM policy.
@@ -848,23 +829,19 @@ func (r *ramPolicyResource) removePolicy(state *ramPolicyResourceModel) diag.Dia
 					return handleAPIError(err)
 				}
 			}
+			return nil
 		}
-
-		return nil
-	}
-
-	reconnectBackoff := backoff.NewExponentialBackOff()
-	reconnectBackoff.MaxElapsedTime = 30 * time.Second
-	err := backoff.Retry(removePolicy, reconnectBackoff)
-	if err != nil {
-		return diag.Diagnostics{
-			diag.NewErrorDiagnostic(
-				"[API ERROR] Failed to Delete Policy",
-				err.Error(),
-			),
+		reconnectBackoff := backoff.NewExponentialBackOff()
+		reconnectBackoff.MaxElapsedTime = 30 * time.Second
+		if err := backoff.Retry(removePolicy, reconnectBackoff); err != nil {
+			return diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"[API ERROR] Failed to Delete Policy",
+					err.Error(),
+				),
+			}
 		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
📝 Description:
- This PR improves the backoff retry mechanism for batch CreatePolicy and RemovePolicy operations by applying retries per policy rather than on the entire batch.

🐛 Problem:
- Retrying the whole batch causes failures when some policies are already created or removed.
- Leads to inconsistent state and unnecessary errors due to partial success on previous attempts.

✅ Solution:
- Implement per-policy retry logic.
- Ensures cleaner handling of transient errors and avoids redundant failures.

🎯 Outcome:
- More robust and reliable batch policy operations
- Reduces error noise and avoids redundant retries on already-processed items