### PR TITLE
Normalize error codes to lowercase for retryable error handling

### DIFF
--- a/alicloud/errorlist.go
+++ b/alicloud/errorlist.go
@@ -1,21 +1,23 @@
 package alicloud
 
+import "strings"
+
 const (
-	ERR_CLOSE_DNS_SLB_FAILED  = "CloseDnsSlbFailed"
-	ERR_DISABLE_DNS_SLB       = "DisableDNSSLB"
-	ERR_ENABLE_DNS_SLB_FAILED = "EnableDnsSlbFailed"
-	ERR_DNS_SYSTEM_BUSYNESS   = "DnsSystemBusyness"
-	ERR_SERVICE_UNAVAILABLE   = "ServiceUnavailable"
-	ERR_THROTTLING_USER       = "Throttling.User"
-	ERR_THROTTLING_API        = "Throttling.API"
-	ERR_THROTTLING            = "Throttling"
-	ERR_UNKNOWN_ERROR         = "UnknownError"
-	ERR_INTERNAL_ERROR        = "InternalError"
-	ERR_BACKEND_TIMEOUT       = "D504TO"
+	ERR_CLOSE_DNS_SLB_FAILED  = "closednsslbfailed"
+	ERR_DISABLE_DNS_SLB       = "disablednsslb"
+	ERR_ENABLE_DNS_SLB_FAILED = "enablednsslbfailed"
+	ERR_DNS_SYSTEM_BUSYNESS   = "dnssystembusyness"
+	ERR_SERVICE_UNAVAILABLE   = "serviceunavailable"
+	ERR_THROTTLING_USER       = "throttling.user"
+	ERR_THROTTLING_API        = "throttling.api"
+	ERR_THROTTLING            = "throttling"
+	ERR_UNKNOWN_ERROR         = "unknownerror"
+	ERR_INTERNAL_ERROR        = "internalerror"
+	ERR_BACKEND_TIMEOUT       = "d504to"
 )
 
 func isAbleToRetry(errCode string) bool {
-	switch errCode {
+	switch strings.ToLower(errCode) {
 	case ERR_CLOSE_DNS_SLB_FAILED,
 		ERR_DISABLE_DNS_SLB,
 		ERR_ENABLE_DNS_SLB_FAILED,


### PR DESCRIPTION
This PR standardizes error code handling by converting all entries in retryableErrors to lowercase and ensuring that incoming error codes are transformed using toLowerCase() before being evaluated in the switch statement.

**Changes made**
- Updated all error codes in retryableErrors to lowercase format
- Applied toLowerCase() to incoming error codes in the switch case
- Ensured consistent comparison logic to prevent case-sensitivity issues